### PR TITLE
handle newlines and quotes within fields

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -21,7 +21,7 @@
 # 
 impl.productID=pentaho-cpython-plugin
 impl.productID=pentaho-cpython-plugin
-project.revision=6.0-SNAPSHOT
+project.revision=6.1-SNAPSHOT
 ivy.artifact.group=pentaho
 ivy.artifact.id=pentaho-cpython-plugin
 package.id=pentaho-cpython-plugin-package
@@ -33,9 +33,9 @@ source.publish=false
 
 junit.maxmemory=500M
 
-dependency.kettle.revision=6.0-SNAPSHOT
-dependency.kettle5-log4j.revision=6.0-SNAPSHOT
-dependency.pentaho-metastore.revision=6.0-SNAPSHOT
+dependency.kettle.revision=6.1-SNAPSHOT
+dependency.kettle5-log4j.revision=6.1-SNAPSHOT
+dependency.pentaho-metastore.revision=6.1-SNAPSHOT
 dependency.guava.revision=13.0.1
 dependency.commons-io.revision=1.3.2
 dependency.jackson-core.revision=1.9.13

--- a/resources/py/pyServer.py
+++ b/resources/py/pyServer.py
@@ -220,7 +220,7 @@ def send_response(response, isJson):
         response = json.dumps(response)
 
     if _global_python3 is True:
-        _global_connection.sendall(struct.pack('>L', len(response)))
+        _global_connection.sendall(struct.pack('>L', len(response.encode('utf-8'))))
         _global_connection.sendall(response.encode('utf-8'))
     else:
         _global_connection.sendall(struct.pack('>L', len(response)))

--- a/resources/py/pyServer.py
+++ b/resources/py/pyServer.py
@@ -26,6 +26,7 @@ import traceback
 import pandas as pd
 import matplotlib
 import matplotlib.pyplot as plt
+import csv
 
 _global_python3 = sys.version_info >= (3, 0)
 
@@ -180,7 +181,7 @@ def send_rows(message):
     send_response(response, True)
     s = StringIO()
     frame.to_csv(path_or_buf=s, na_rep='?', doublequote=False, index=include_index,
-                 quotechar='\'',
+                 quotechar='\'', line_terminator='#||#', quoting=csv.QUOTE_NONNUMERIC,
                  escapechar='\\', header=False, date_format='%Y-%m-%d %H:%M:%S.%f')
     send_response(s.getvalue(), False)
 

--- a/src/org/pentaho/python/ServerUtils.java
+++ b/src/org/pentaho/python/ServerUtils.java
@@ -562,10 +562,9 @@ public class ServerUtils {
     RowMetaAndRows rowMetaAndRows = new RowMetaAndRows();
     rowMetaAndRows.m_rowMeta = kettleMeta;
     rowMetaAndRows.m_rows = new Object[numRows][];
-    BufferedReader reader = new BufferedReader( new StringReader( csv ) );
-    String line;
     int count = 0;
-    while ( ( line = reader.readLine() ) != null ) {
+    for(String line: csv.split("#\\|\\|#")){
+      line = line.replace("\r\n", "<newline>");
       String[] parsed = PARSER.parseLine( line );
 
       Object[] row = new Object[kettleMeta.size()];

--- a/src/org/pentaho/python/ServerUtils.java
+++ b/src/org/pentaho/python/ServerUtils.java
@@ -563,8 +563,10 @@ public class ServerUtils {
     rowMetaAndRows.m_rowMeta = kettleMeta;
     rowMetaAndRows.m_rows = new Object[numRows][];
     int count = 0;
+    // use a foreign line ending so that we can still have cr/lf in text cells
     for(String line: csv.split("#\\|\\|#")){
-      line = line.replace("\r\n", "<newline>");
+      // stash cr and lf so that they don't break the parser
+      line = line.replace("\n", "<lf>").replace("\r", "<cr>");
       String[] parsed = PARSER.parseLine( line );
 
       Object[] row = new Object[kettleMeta.size()];
@@ -591,7 +593,8 @@ public class ServerUtils {
             }
             break;
           default:
-            row[i] = parsed[i];
+            // unpack stashed cr lf 
+            row[i] = parsed[i].replace("<lf>", "\n").replace("<cr>", "\r");
         }
       }
       rowMetaAndRows.m_rows[count++] = row;


### PR DESCRIPTION
Hi Mark -

I have just come across an instance where I have been importing survey data into a Pandas DataFrame and some of the text columns had quotes and newlines in the data.  This caused problems on the shuffle of data from Python back to Kettle in that it broke the CSV.

This PR is a starting point for potentially resolving this -  the biggest problem is in deciding what to do with newline markers ("\r\n" in my case) I substituted them for <newline>.

Cheers,
Piers Harding. 
